### PR TITLE
Improve shortcuts UX: hover-reveal add button, keyboard edit shortcut

### DIFF
--- a/home/index.html
+++ b/home/index.html
@@ -109,10 +109,11 @@
           <button
             class="modal-btn primary"
             id="editShortcutsBtn"
-            style="width: 100%; margin-bottom: 1rem"
+            style="width: 100%; margin-bottom: 0.6rem"
           >
             Edit Shortcuts
           </button>
+          <p class="shortcut-hint">Hover a shortcut, then press <kbd>E</kbd> to edit</p>
         </div>
 
         <div class="settings-section">

--- a/home/shortcuts.js
+++ b/home/shortcuts.js
@@ -3,6 +3,7 @@ let isEditMode = false;
 let shortcuts = [];
 let editingIndex = -1;
 let hoveredShortcutIndex = -1;
+let escapeHandler = null;
 
 // Load shortcuts from storage
 function loadShortcuts() {
@@ -155,10 +156,29 @@ function toggleEditMode() {
     if (banner) {
       banner.classList.add("active");
     }
+    if (escapeHandler) {
+      document.removeEventListener("keydown", escapeHandler);
+    }
+    const addModal = document.getElementById("addShortcutModal");
+    escapeHandler = function (e) {
+      if (e.key !== "Escape") return;
+      if (editingIndex !== -1) {
+        closeEditModal();
+      } else if (addModal && addModal.classList.contains("active")) {
+        closeAddModal();
+      } else {
+        toggleEditMode();
+      }
+    };
+    document.addEventListener("keydown", escapeHandler);
   } else {
     grid.classList.remove("edit-mode");
     if (banner) {
       banner.classList.remove("active");
+    }
+    if (escapeHandler) {
+      document.removeEventListener("keydown", escapeHandler);
+      escapeHandler = null;
     }
   }
 

--- a/home/styles.css
+++ b/home/styles.css
@@ -15,8 +15,16 @@
 }
 
 body {
-  font-family: "Vollkorn", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-    Oxygen, Ubuntu, Cantarell, sans-serif;
+  font-family:
+    "Vollkorn",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    Oxygen,
+    Ubuntu,
+    Cantarell,
+    sans-serif;
   background: var(--zen-paper);
   color: var(--zen-dark);
   min-height: 100vh;
@@ -72,7 +80,12 @@ body {
   padding: 1.1rem 1.5rem;
   color: var(--zen-dark);
   font-size: 1.1rem;
-  font-family: "Vollkorn", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto;
+  font-family:
+    "Vollkorn",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto;
   font-weight: 400;
   outline: none;
   transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
@@ -169,7 +182,12 @@ body {
   border-radius: 8px;
   padding: 0.5rem 1.25rem;
   color: var(--zen-paper);
-  font-family: "Vollkorn", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto;
+  font-family:
+    "Vollkorn",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto;
   font-size: 0.9rem;
   cursor: pointer;
   transition: all 0.3s ease;
@@ -288,12 +306,25 @@ body {
 }
 
 .shortcut-add {
-  border: 1px dashed rgba(209, 207, 192, 0.2);
   background: transparent;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+  transition-delay: 0s;
+}
+
+.shortcuts-grid:hover .shortcut-add {
+  opacity: 1;
+  pointer-events: auto;
+  transition-delay: 500ms;
+}
+
+.shortcuts-grid.edit-mode .shortcut-add {
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .shortcut-add:hover {
-  border-color: var(--accent-color);
   background: rgba(247, 111, 83, 0.05);
 }
 
@@ -412,7 +443,12 @@ body {
   padding: 0.75rem 1rem;
   color: var(--zen-dark);
   font-size: 0.95rem;
-  font-family: "Vollkorn", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto;
+  font-family:
+    "Vollkorn",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto;
   outline: none;
   margin-bottom: 1rem;
   transition: all 0.3s ease;
@@ -436,7 +472,12 @@ body {
   border: 1px solid rgba(209, 207, 192, 0.15);
   background: transparent;
   color: var(--zen-dark);
-  font-family: "Vollkorn", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto;
+  font-family:
+    "Vollkorn",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto;
   font-size: 0.95rem;
   cursor: pointer;
   transition: all 0.3s ease;
@@ -444,6 +485,25 @@ body {
 
 .modal-btn:hover {
   background: rgba(209, 207, 192, 0.05);
+}
+
+.shortcut-hint {
+  font-size: 0.75rem;
+  color: rgba(209, 207, 192, 0.45);
+  text-align: center;
+  margin-bottom: 0.5rem;
+}
+
+.shortcut-hint kbd {
+  display: inline-block;
+  padding: 0.1em 0.4em;
+  font-size: 0.7rem;
+  font-family: monospace;
+  background: rgba(209, 207, 192, 0.08);
+  border: 1px solid rgba(209, 207, 192, 0.2);
+  border-radius: 4px;
+  color: rgba(209, 207, 192, 0.6);
+  line-height: 1.4;
 }
 
 .modal-btn.primary {
@@ -550,7 +610,12 @@ body {
   border: 1px solid rgba(209, 207, 192, 0.12);
   border-radius: 8px;
   color: var(--zen-dark);
-  font-family: "Vollkorn", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto;
+  font-family:
+    "Vollkorn",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto;
   font-size: 0.95rem;
   cursor: pointer;
   transition: all 0.3s ease;
@@ -609,7 +674,9 @@ button svg {
   background-position: center;
   background-repeat: no-repeat;
   position: relative;
-  transition: opacity 0.2s ease, filter 0.2s ease;
+  transition:
+    opacity 0.2s ease,
+    filter 0.2s ease;
 }
 
 .preview-background::after {
@@ -662,7 +729,12 @@ button svg {
   border: none;
   border-radius: 8px;
   color: rgba(209, 207, 192, 0.6);
-  font-family: "Vollkorn", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto;
+  font-family:
+    "Vollkorn",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto;
   font-size: 0.95rem;
   cursor: pointer;
   transition: all 0.3s ease;
@@ -718,7 +790,9 @@ button svg {
   background-position: center;
   background-repeat: no-repeat;
   z-index: -2;
-  transition: opacity 0.3s ease, filter 0.3s ease;
+  transition:
+    opacity 0.3s ease,
+    filter 0.3s ease;
 }
 
 .wallpaper-background::after {


### PR DESCRIPTION
## Description

Video will probably showcase this better and faster 😅

https://github.com/user-attachments/assets/5d34b7a4-b959-42ca-9876-a5b16d6df7e9


                                          
### What changed                                  
                                         
  - Hover-reveal add button — the + shortcut button is now always rendered in the grid but hidden by default. It fades in after a short delay when hovering over the shortcuts area,
  removing the need to enter edit mode just to add a shortcut.
  - `E` key to edit — hovering over a shortcut and pressing E activates edit mode and opens the edit modal for that specific shortcut, reducing clicks.
  - `Escape` key support — pressing Escape closes the topmost open layer: edit modal first, then add modal, then exits edit mode entirely. The listener is only active while edit mode is on.
  - Keyboard hint — a small hint line with a styled `<kbd>E</kbd>` chip now appears below the "Edit Shortcuts" button in the settings modal so users can discover the shortcut.
  - Removed dashed border from the add button for a cleaner look

### Technical notes

- Hover tracking uses a single delegated mouseover/mouseleave listener on the grid rather than per-item listeners, avoiding churn on re-renders.
- `e.preventDefault()` on the keydown handler prevents the **E** character from being typed into the focused modal input.
- Escape keydown listener is attached/detached in `toggleEditMode()` so it only exists while edit mode is active. Includes a guard against double-attach to prevent listener leaks.
- DOM query for the add modal is hoisted to handler construction time rather than queried on every Escape press.