### PR TITLE
light/dark/system theme toggle with per-theme background colors

### DIFF
--- a/home/index.html
+++ b/home/index.html
@@ -4,9 +4,15 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Home</title>
+    <script>
+      (function () {
+        var t = localStorage.getItem("zenThemeCache") || (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+        document.documentElement.setAttribute("data-theme", t);
+        var c = localStorage.getItem("zenBgColorCache_" + t);
+        if (c) document.documentElement.style.setProperty("--zen-paper", c);
+      })();
+    </script>
     <link rel="stylesheet" href="styles.css" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -49,7 +55,9 @@
 
     <div class="config-buttons">
       <button class="settings-btn" id="settingsBtn" title="Settings">
-        <img src="../icons/settings.svg" alt="Settings" />
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M10.65 3L9.93163 3.53449L9.32754 5.54812L7.47651 4.55141L6.5906 4.68143L4.68141 6.59062L4.55139 7.47652L5.5481 9.32755L3.53449 9.93163L3 10.65V13.35L3.53449 14.0684L5.54811 14.6725L4.55142 16.5235L4.68144 17.4094L6.59063 19.3186L7.47653 19.4486L9.32754 18.4519L9.93163 20.4655L10.65 21H13.35L14.0684 20.4655L14.6725 18.4519L16.5235 19.4486L17.4094 19.3185L19.3186 17.4094L19.4486 16.5235L18.4519 14.6724L20.4655 14.0684L21 13.35V10.65L20.4655 9.93163L18.4519 9.32754L19.4486 7.47654L19.3186 6.59063L17.4094 4.68144L16.5235 4.55142L14.6725 5.54812L14.0684 3.53449L13.35 3H10.65ZM10.4692 6.96284L11.208 4.5H12.792L13.5308 6.96284L13.8753 7.0946C13.9654 7.12908 14.0543 7.16597 14.142 7.2052L14.4789 7.35598L16.7433 6.13668L17.8633 7.25671L16.644 9.52111L16.7948 9.85803C16.834 9.9457 16.8709 10.0346 16.9054 10.1247L17.0372 10.4692L19.5 11.208V12.792L17.0372 13.5308L16.9054 13.8753C16.8709 13.9654 16.834 14.0543 16.7948 14.1419L16.644 14.4789L17.8633 16.7433L16.7433 17.8633L14.4789 16.644L14.142 16.7948C14.0543 16.834 13.9654 16.8709 13.8753 16.9054L13.5308 17.0372L12.792 19.5H11.208L10.4692 17.0372L10.1247 16.9054C10.0346 16.8709 9.94569 16.834 9.85803 16.7948L9.52111 16.644L7.25671 17.8633L6.13668 16.7433L7.35597 14.4789L7.2052 14.142C7.16597 14.0543 7.12908 13.9654 7.0946 13.8753L6.96284 13.5308L4.5 12.792L4.5 11.208L6.96284 10.4692L7.0946 10.1247C7.12907 10.0346 7.16596 9.94571 7.20519 9.85805L7.35596 9.52113L6.13666 7.2567L7.25668 6.13667L9.5211 7.35598L9.85803 7.2052C9.9457 7.16597 10.0346 7.12908 10.1247 7.0946L10.4692 6.96284ZM14.25 12C14.25 13.2426 13.2426 14.25 12 14.25C10.7574 14.25 9.75 13.2426 9.75 12C9.75 10.7574 10.7574 9.75 12 9.75C13.2426 9.75 14.25 10.7574 14.25 12ZM15.75 12C15.75 14.0711 14.0711 15.75 12 15.75C9.92893 15.75 8.25 14.0711 8.25 12C8.25 9.92893 9.92893 8.25 12 8.25C14.0711 8.25 15.75 9.92893 15.75 12Z" fill="currentColor"/>
+        </svg>
       </button>
     </div>
 
@@ -105,6 +113,15 @@
         <h2 class="modal-title">Settings</h2>
 
         <div class="settings-section">
+          <h3 class="settings-subtitle">Appearance</h3>
+          <div class="theme-selector">
+            <button class="theme-option" data-theme="dark">Dark</button>
+            <button class="theme-option" data-theme="light">Light</button>
+            <button class="theme-option" data-theme="system">System</button>
+          </div>
+        </div>
+
+        <div class="settings-section">
           <h3 class="settings-subtitle">Shortcuts</h3>
           <button
             class="modal-btn primary"
@@ -144,15 +161,6 @@
 
           <!-- Collapsible Background Content -->
           <div id="backgroundContent" style="display: block">
-            <!-- Live Preview -->
-            <div class="wallpaper-live-preview" id="wallpaperLivePreview">
-              <div class="preview-background" id="previewBackground">
-                <div class="preview-content" id="previewContent">
-                  <span class="preview-label">Live Preview</span>
-                </div>
-              </div>
-            </div>
-
             <!-- Tab Navigation -->
             <div class="background-tabs" style="margin-top: 1rem">
               <button class="tab-btn active" id="colorTab" data-tab="color">
@@ -169,28 +177,59 @@
               <div class="tab-content active" id="colorTabContent">
                 <div style="margin-top: 1rem">
                   <label class="settings-label" style="margin-bottom: 0.75rem">
-                    <span>Choose a solid background color:</span>
+                    <span>Background color per theme:</span>
                   </label>
-                  <div style="display: flex; gap: 0.5rem; align-items: center">
-                    <input
-                      type="color"
-                      id="wallpaperColor"
-                      value="#1f1f1f"
-                      class="color-picke"
-                    />
-                    <button
-                      class="modal-btn primary"
-                      id="applyColorBtn"
-                      style="flex: 1; margin: 0"
-                    >
-                      Apply Color
-                    </button>
+                  <div class="theme-color-grid">
+                    <div class="theme-color-item">
+                      <div
+                        class="theme-color-swatch"
+                        id="darkColorSwatch"
+                        style="background-color: #1f1f1f"
+                      >
+                        <input
+                          type="color"
+                          id="wallpaperColorDark"
+                          value="#1f1f1f"
+                        />
+                      </div>
+                      <span class="theme-color-label">dark</span>
+                    </div>
+                    <div class="theme-color-item">
+                      <div
+                        class="theme-color-swatch"
+                        id="lightColorSwatch"
+                        style="background-color: #f5f3ec"
+                      >
+                        <input
+                          type="color"
+                          id="wallpaperColorLight"
+                          value="#f5f3ec"
+                        />
+                      </div>
+                      <span class="theme-color-label">light</span>
+                    </div>
                   </div>
+                  <button
+                    class="modal-btn primary"
+                    id="applyColorBtn"
+                    style="width: 100%; margin: 0.75rem 0 0"
+                  >
+                    Apply Colors
+                  </button>
                 </div>
               </div>
 
               <!-- Image Tab Content -->
               <div class="tab-content" id="imageTabContent">
+                <!-- Live Preview -->
+                <div class="wallpaper-live-preview" id="wallpaperLivePreview" style="margin-top: 1rem">
+                  <div class="preview-background" id="previewBackground">
+                    <div class="preview-content" id="previewContent">
+                      <span class="preview-label">Live Preview</span>
+                    </div>
+                  </div>
+                </div>
+
                 <!-- Drag and Drop Area -->
                 <div
                   class="drag-drop-area"
@@ -243,7 +282,7 @@
                     style="
                       display: block;
                       margin-bottom: 1rem;
-                      color: rgba(209, 207, 192, 0.7);
+                      color: rgba(var(--zen-dark-rgb), 0.7);
                       font-size: 0.9rem;
                     "
                     >Effects</span
@@ -314,7 +353,7 @@
                 id="resetAllBtn"
                 style="
                   flex: 1;
-                  background: rgba(209, 207, 192, 0.1);
+                  background: rgba(var(--zen-dark-rgb), 0.1);
                   color: var(--zen-dark);
                   margin: 0;
                 "

--- a/home/index.html
+++ b/home/index.html
@@ -4,14 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Home</title>
-    <script>
-      (function () {
-        var t = localStorage.getItem("zenThemeCache") || (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
-        document.documentElement.setAttribute("data-theme", t);
-        var c = localStorage.getItem("zenBgColorCache_" + t);
-        if (c) document.documentElement.style.setProperty("--zen-paper", c);
-      })();
-    </script>
+    <script src="loadTheme.js"></script>
     <link rel="stylesheet" href="styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/home/index.js
+++ b/home/index.js
@@ -189,9 +189,14 @@ async function fetchBingImageOfTheDay() {
 // ===== Theme functionality =====
 
 const THEME_BG_DEFAULTS = { dark: "#1f1f1f", light: "#f5f3ec" };
+const THEME_BG_KEYS = { dark: "zenBgColorDark", light: "zenBgColorLight" };
+
+function resolveSystemTheme() {
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
 
 function getThemeBgKey(theme) {
-  return "zenBgColor" + theme.charAt(0).toUpperCase() + theme.slice(1);
+  return THEME_BG_KEYS[theme === "system" ? resolveSystemTheme() : theme];
 }
 
 function applyThemeBgColor(hexColor) {
@@ -203,13 +208,7 @@ function applyThemeBgColor(hexColor) {
 }
 
 function loadThemeBgColor(theme) {
-  let key;
-  if (theme === "system") {
-    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-    key = prefersDark ? "zenBgColorDark" : "zenBgColorLight";
-  } else {
-    key = getThemeBgKey(theme);
-  }
+  const key = getThemeBgKey(theme);
   browser.storage.local.get(key, function (result) {
     const color = result[key] || null;
     applyThemeBgColor(color);
@@ -260,6 +259,8 @@ document.addEventListener("DOMContentLoaded", function () {
   const dragDropArea = document.getElementById("dragDropArea");
   const wallpaperColorDark = document.getElementById("wallpaperColorDark");
   const wallpaperColorLight = document.getElementById("wallpaperColorLight");
+  const darkColorSwatch = document.getElementById("darkColorSwatch");
+  const lightColorSwatch = document.getElementById("lightColorSwatch");
   const applyColorBtn = document.getElementById("applyColorBtn");
   const effectsControls = document.getElementById("effectsControls");
   const opacitySlider = document.getElementById("wallpaperOpacity");
@@ -375,14 +376,12 @@ document.addEventListener("DOMContentLoaded", function () {
   // Live swatch color update as user drags the color picker
   if (wallpaperColorDark) {
     wallpaperColorDark.addEventListener("input", function () {
-      const swatch = document.getElementById("darkColorSwatch");
-      if (swatch) swatch.style.backgroundColor = this.value;
+      if (darkColorSwatch) darkColorSwatch.style.backgroundColor = this.value;
     });
   }
   if (wallpaperColorLight) {
     wallpaperColorLight.addEventListener("input", function () {
-      const swatch = document.getElementById("lightColorSwatch");
-      if (swatch) swatch.style.backgroundColor = this.value;
+      if (lightColorSwatch) lightColorSwatch.style.backgroundColor = this.value;
     });
   }
 
@@ -390,28 +389,11 @@ document.addEventListener("DOMContentLoaded", function () {
   const settingsBtn = document.getElementById("settingsBtn");
   if (settingsBtn) {
     settingsBtn.addEventListener("click", function () {
-      browser.storage.local.get("zenTheme", function (result) {
-        const theme = result.zenTheme || "dark";
-        document.querySelectorAll(".theme-option").forEach(function (btn) {
-          btn.classList.toggle("active", btn.dataset.theme === theme);
-        });
-        browser.storage.local.get(
-          ["zenBgColorDark", "zenBgColorLight"],
-          function (colors) {
-            const darkColor = colors.zenBgColorDark || THEME_BG_DEFAULTS.dark;
-            const lightColor = colors.zenBgColorLight || THEME_BG_DEFAULTS.light;
-            const darkSwatch = document.getElementById("darkColorSwatch");
-            const lightSwatch = document.getElementById("lightColorSwatch");
-            if (wallpaperColorDark) wallpaperColorDark.value = darkColor;
-            if (wallpaperColorLight) wallpaperColorLight.value = lightColor;
-            if (darkSwatch) darkSwatch.style.backgroundColor = darkColor;
-            if (lightSwatch) lightSwatch.style.backgroundColor = lightColor;
-          }
-        );
-      });
-
       browser.storage.local.get(
         [
+          "zenTheme",
+          THEME_BG_KEYS.dark,
+          THEME_BG_KEYS.light,
           "wallpaperImage",
           "wallpaperOpacity",
           "wallpaperBlur",
@@ -420,6 +402,18 @@ document.addEventListener("DOMContentLoaded", function () {
           "backgroundSectionOpen",
         ],
         function (result) {
+          const theme = result.zenTheme || "dark";
+          document.querySelectorAll(".theme-option").forEach(function (btn) {
+            btn.classList.toggle("active", btn.dataset.theme === theme);
+          });
+
+          const darkColor = result[THEME_BG_KEYS.dark] || THEME_BG_DEFAULTS.dark;
+          const lightColor = result[THEME_BG_KEYS.light] || THEME_BG_DEFAULTS.light;
+          if (wallpaperColorDark) wallpaperColorDark.value = darkColor;
+          if (wallpaperColorLight) wallpaperColorLight.value = lightColor;
+          if (darkColorSwatch) darkColorSwatch.style.backgroundColor = darkColor;
+          if (lightColorSwatch) lightColorSwatch.style.backgroundColor = lightColor;
+
           const opacity =
             result.wallpaperOpacity !== undefined
               ? result.wallpaperOpacity
@@ -470,27 +464,20 @@ document.addEventListener("DOMContentLoaded", function () {
           } else {
             updatePreview(null, 50, 0, 0, isImageTab);
             toggleEffectsControls(false);
-            const currentTheme =
-              document.documentElement.getAttribute("data-theme") || "dark";
-            const resolvedKey =
-              currentTheme === "system"
-                ? window.matchMedia("(prefers-color-scheme: dark)").matches
-                  ? "zenBgColorDark"
-                  : "zenBgColorLight"
-                : getThemeBgKey(currentTheme);
-            browser.storage.local.get(resolvedKey, function (cr) {
-              if (cr[resolvedKey]) {
-                const pb = document.getElementById("previewBackground");
-                const pc = document.getElementById("previewContent");
-                if (pb) {
-                  pb.style.backgroundImage = "none";
-                  pb.style.backgroundColor = cr[resolvedKey];
-                  pb.style.opacity = 1;
-                  pb.style.filter = "none";
-                }
-                if (pc) pc.style.display = "none";
+            const resolvedKey = getThemeBgKey(
+              document.documentElement.getAttribute("data-theme") || "dark"
+            );
+            if (result[resolvedKey]) {
+              const pb = document.getElementById("previewBackground");
+              const pc = document.getElementById("previewContent");
+              if (pb) {
+                pb.style.backgroundImage = "none";
+                pb.style.backgroundColor = result[resolvedKey];
+                pb.style.opacity = 1;
+                pb.style.filter = "none";
               }
-            });
+              if (pc) pc.style.display = "none";
+            }
           }
         }
       );
@@ -613,22 +600,16 @@ document.addEventListener("DOMContentLoaded", function () {
       const lightColor = wallpaperColorLight ? wallpaperColorLight.value : THEME_BG_DEFAULTS.light;
 
       browser.storage.local.set({
-        zenBgColorDark: darkColor,
-        zenBgColorLight: lightColor,
+        [THEME_BG_KEYS.dark]: darkColor,
+        [THEME_BG_KEYS.light]: lightColor,
       });
       localStorage.setItem("zenBgColorCache_dark", darkColor);
       localStorage.setItem("zenBgColorCache_light", lightColor);
 
       const theme =
         document.documentElement.getAttribute("data-theme") || "dark";
-      let colorToApply = darkColor;
-      if (theme === "light") {
-        colorToApply = lightColor;
-      } else if (theme === "system") {
-        colorToApply = window.matchMedia("(prefers-color-scheme: dark)").matches
-          ? darkColor
-          : lightColor;
-      }
+      const resolved = theme === "system" ? resolveSystemTheme() : theme;
+      const colorToApply = resolved === "light" ? lightColor : darkColor;
       applyThemeBgColor(colorToApply);
 
       const pb = document.getElementById("previewBackground");
@@ -687,8 +668,8 @@ document.addEventListener("DOMContentLoaded", function () {
           "wallpaperGrain",
           "isBingImage",
           "bingImageDate",
-          "zenBgColorDark",
-          "zenBgColorLight",
+          THEME_BG_KEYS.dark,
+          THEME_BG_KEYS.light,
         ]);
         localStorage.removeItem("zenBgColorCache_dark");
         localStorage.removeItem("zenBgColorCache_light");
@@ -702,10 +683,8 @@ document.addEventListener("DOMContentLoaded", function () {
         wallpaperUpload.value = "";
         if (wallpaperColorDark) wallpaperColorDark.value = THEME_BG_DEFAULTS.dark;
         if (wallpaperColorLight) wallpaperColorLight.value = THEME_BG_DEFAULTS.light;
-        const dSwatch = document.getElementById("darkColorSwatch");
-        const lSwatch = document.getElementById("lightColorSwatch");
-        if (dSwatch) dSwatch.style.backgroundColor = THEME_BG_DEFAULTS.dark;
-        if (lSwatch) lSwatch.style.backgroundColor = THEME_BG_DEFAULTS.light;
+        if (darkColorSwatch) darkColorSwatch.style.backgroundColor = THEME_BG_DEFAULTS.dark;
+        if (lightColorSwatch) lightColorSwatch.style.backgroundColor = THEME_BG_DEFAULTS.light;
 
         // Reset sliders
         opacitySlider.value = 50;

--- a/home/loadTheme.js
+++ b/home/loadTheme.js
@@ -1,0 +1,6 @@
+(function () {
+  var t = localStorage.getItem("zenThemeCache") || (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+  document.documentElement.setAttribute("data-theme", t);
+  var c = localStorage.getItem("zenBgColorCache_" + t);
+  if (c) document.documentElement.style.setProperty("--zen-paper", c);
+})();

--- a/home/styles.css
+++ b/home/styles.css
@@ -1,11 +1,47 @@
 /* Style of the Zen Home Page */
 
-:root {
+/* Dark theme — default */
+:root,
+html[data-theme="dark"] {
   --zen-paper: #1f1f1f;
   --zen-dark: #d1cfc0;
+  --zen-dark-rgb: 209, 207, 192;
   --zen-muted: rgba(255, 255, 255, 0.05);
   --zen-subtle: rgba(255, 255, 255, 0.1);
   --accent-color: rgb(247, 111, 83);
+}
+
+/* Light theme */
+html[data-theme="light"] {
+  --zen-paper: #f5f3ec;
+  --zen-dark: #2a2826;
+  --zen-dark-rgb: 42, 40, 38;
+  --zen-muted: rgba(0, 0, 0, 0.04);
+  --zen-subtle: rgba(0, 0, 0, 0.08);
+  --accent-color: rgb(247, 111, 83);
+}
+
+/* System theme — delegates to OS preference */
+@media (prefers-color-scheme: light) {
+  html[data-theme="system"] {
+    --zen-paper: #f5f3ec;
+    --zen-dark: #2a2826;
+    --zen-dark-rgb: 42, 40, 38;
+    --zen-muted: rgba(0, 0, 0, 0.04);
+    --zen-subtle: rgba(0, 0, 0, 0.08);
+    --accent-color: rgb(247, 111, 83);
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  html[data-theme="system"] {
+    --zen-paper: #1f1f1f;
+    --zen-dark: #d1cfc0;
+    --zen-dark-rgb: 209, 207, 192;
+    --zen-muted: rgba(255, 255, 255, 0.05);
+    --zen-subtle: rgba(255, 255, 255, 0.1);
+    --accent-color: rgb(247, 111, 83);
+  }
 }
 
 * {
@@ -50,7 +86,7 @@ body {
 }
 
 .subtitle {
-  color: rgba(209, 207, 192, 0.5);
+  color: rgba(var(--zen-dark-rgb), 0.5);
   font-size: 1rem;
   margin-bottom: 4rem;
   line-height: 1.8;
@@ -66,8 +102,8 @@ body {
 
 .search-input {
   width: 100%;
-  background: rgba(209, 207, 192, 0.03);
-  border: 1px solid rgba(209, 207, 192, 0.12);
+  background: rgba(var(--zen-dark-rgb), 0.03);
+  border: 1px solid rgba(var(--zen-dark-rgb), 0.12);
   border-radius: 12px;
   padding: 1.1rem 1.5rem;
   color: var(--zen-dark);
@@ -80,18 +116,18 @@ body {
 }
 
 .search-input::placeholder {
-  color: rgba(209, 207, 192, 0.3);
+  color: rgba(var(--zen-dark-rgb), 0.3);
   font-style: italic;
   font-weight: 300;
 }
 
 .search-input:focus {
   border-color: var(--zen-subtle);
-  background: rgba(209, 207, 192, 0.05);
+  background: rgba(var(--zen-dark-rgb), 0.05);
 }
 
 .search-input:focus::placeholder {
-  color: rgba(209, 207, 192, 0.2);
+  color: rgba(var(--zen-dark-rgb), 0.2);
   transform: translateX(4px);
 }
 
@@ -237,8 +273,8 @@ body {
   width: 48px;
   height: 48px;
   border-radius: 12px;
-  background: rgba(209, 207, 192, 0.05);
-  border: 1px solid rgba(209, 207, 192, 0.12);
+  background: rgba(var(--zen-dark-rgb), 0.05);
+  border: 1px solid rgba(var(--zen-dark-rgb), 0.12);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -250,7 +286,7 @@ body {
 
 .shortcut-item:hover .shortcut-icon {
   border-color: var(--accent-color);
-  background: rgba(209, 207, 192, 0.08);
+  background: rgba(var(--zen-dark-rgb), 0.08);
 }
 
 .edit-mode .shortcut-item .shortcut-icon {
@@ -288,7 +324,7 @@ body {
 }
 
 .shortcut-add {
-  border: 1px dashed rgba(209, 207, 192, 0.2);
+  border: 1px dashed rgba(var(--zen-dark-rgb), 0.2);
   background: transparent;
 }
 
@@ -301,7 +337,7 @@ body {
   background: transparent;
   border: none;
   font-size: 1.5rem;
-  color: rgba(209, 207, 192, 0.4);
+  color: rgba(var(--zen-dark-rgb), 0.4);
 }
 
 .remove-shortcut {
@@ -344,8 +380,8 @@ body {
   width: 48px;
   height: 48px;
   border-radius: 50%;
-  background: rgba(209, 207, 192, 0.08);
-  border: 1px solid rgba(209, 207, 192, 0.15);
+  background: rgba(var(--zen-dark-rgb), 0.08);
+  border: 1px solid rgba(var(--zen-dark-rgb), 0.15);
   color: var(--zen-dark);
   font-size: 1.2rem;
   cursor: pointer;
@@ -357,7 +393,7 @@ body {
 }
 
 .settings-btn:hover {
-  background: rgba(209, 207, 192, 0.12);
+  background: rgba(var(--zen-dark-rgb), 0.12);
   border-color: var(--accent-color);
   transform: scale(1.1);
 }
@@ -382,7 +418,7 @@ body {
 
 .modal-content {
   background: var(--zen-paper);
-  border: 1px solid rgba(209, 207, 192, 0.15);
+  border: 1px solid rgba(var(--zen-dark-rgb), 0.15);
   border-radius: 16px;
   padding: 2rem;
   max-width: 400px;
@@ -406,8 +442,8 @@ body {
 
 .modal-input {
   width: 100%;
-  background: rgba(209, 207, 192, 0.03);
-  border: 1px solid rgba(209, 207, 192, 0.12);
+  background: rgba(var(--zen-dark-rgb), 0.03);
+  border: 1px solid rgba(var(--zen-dark-rgb), 0.12);
   border-radius: 8px;
   padding: 0.75rem 1rem;
   color: var(--zen-dark);
@@ -420,7 +456,7 @@ body {
 
 .modal-input:focus {
   border-color: var(--accent-color);
-  background: rgba(209, 207, 192, 0.05);
+  background: rgba(var(--zen-dark-rgb), 0.05);
 }
 
 .modal-buttons {
@@ -433,7 +469,7 @@ body {
   flex: 1;
   padding: 0.75rem 1.5rem;
   border-radius: 8px;
-  border: 1px solid rgba(209, 207, 192, 0.15);
+  border: 1px solid rgba(var(--zen-dark-rgb), 0.15);
   background: transparent;
   color: var(--zen-dark);
   font-family: "Vollkorn", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto;
@@ -443,7 +479,7 @@ body {
 }
 
 .modal-btn:hover {
-  background: rgba(209, 207, 192, 0.05);
+  background: rgba(var(--zen-dark-rgb), 0.05);
 }
 
 .modal-btn.primary {
@@ -546,8 +582,8 @@ body {
   align-items: center;
   gap: 0.75rem;
   padding: 0.75rem 1rem;
-  background: rgba(209, 207, 192, 0.03);
-  border: 1px solid rgba(209, 207, 192, 0.12);
+  background: rgba(var(--zen-dark-rgb), 0.03);
+  border: 1px solid rgba(var(--zen-dark-rgb), 0.12);
   border-radius: 8px;
   color: var(--zen-dark);
   font-family: "Vollkorn", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto;
@@ -557,7 +593,7 @@ body {
 }
 
 .engine-option:hover {
-  background: rgba(209, 207, 192, 0.08);
+  background: rgba(var(--zen-dark-rgb), 0.08);
   border-color: var(--accent-color);
 }
 
@@ -597,9 +633,9 @@ button svg {
   height: 180px;
   border-radius: 12px;
   overflow: hidden;
-  border: 2px solid rgba(209, 207, 192, 0.12);
+  border: 2px solid rgba(var(--zen-dark-rgb), 0.12);
   position: relative;
-  background: rgba(209, 207, 192, 0.03);
+  background: rgba(var(--zen-dark-rgb), 0.03);
 }
 
 .preview-background {
@@ -631,7 +667,7 @@ button svg {
   left: 50%;
   transform: translate(-50%, -50%);
   text-align: center;
-  color: rgba(209, 207, 192, 0.5);
+  color: rgba(var(--zen-dark-rgb), 0.5);
   font-size: 0.9rem;
   font-style: italic;
   pointer-events: none;
@@ -649,10 +685,10 @@ button svg {
 .background-tabs {
   display: flex;
   gap: 0.5rem;
-  background: rgba(209, 207, 192, 0.05);
+  background: rgba(var(--zen-dark-rgb), 0.05);
   padding: 0.25rem;
   border-radius: 10px;
-  border: 1px solid rgba(209, 207, 192, 0.12);
+  border: 1px solid rgba(var(--zen-dark-rgb), 0.12);
 }
 
 .tab-btn {
@@ -661,7 +697,7 @@ button svg {
   background: transparent;
   border: none;
   border-radius: 8px;
-  color: rgba(209, 207, 192, 0.6);
+  color: rgba(var(--zen-dark-rgb), 0.6);
   font-family: "Vollkorn", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto;
   font-size: 0.95rem;
   cursor: pointer;
@@ -671,13 +707,13 @@ button svg {
 
 .tab-btn:hover {
   color: var(--zen-dark);
-  background: rgba(209, 207, 192, 0.05);
+  background: rgba(var(--zen-dark-rgb), 0.05);
 }
 
 .tab-btn.active {
   background: var(--zen-paper);
   color: var(--zen-dark);
-  border: 1px solid rgba(209, 207, 192, 0.15);
+  border: 1px solid rgba(var(--zen-dark-rgb), 0.15);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
@@ -751,7 +787,7 @@ button svg {
   width: 100%;
   height: 6px;
   border-radius: 3px;
-  background: rgba(209, 207, 192, 0.1);
+  background: rgba(var(--zen-dark-rgb), 0.1);
   outline: none;
   -webkit-appearance: none;
   appearance: none;
@@ -790,9 +826,9 @@ button svg {
 .drag-drop-area {
   width: 100%;
   padding: 2rem 1rem;
-  border: 2px dashed rgba(209, 207, 192, 0.3);
+  border: 2px dashed rgba(var(--zen-dark-rgb), 0.3);
   border-radius: 12px;
-  background: rgba(209, 207, 192, 0.03);
+  background: rgba(var(--zen-dark-rgb), 0.03);
   text-align: center;
   cursor: pointer;
   transition: all 0.3s ease;
@@ -825,7 +861,7 @@ button svg {
 }
 
 .drag-drop-subtext {
-  color: rgba(209, 207, 192, 0.5);
+  color: rgba(var(--zen-dark-rgb), 0.5);
   font-size: 0.85rem;
   font-style: italic;
 }
@@ -834,7 +870,7 @@ button svg {
 .color-picker {
   width: 60px;
   height: 40px;
-  border: 1px solid rgba(209, 207, 192, 0.12);
+  border: 1px solid rgba(var(--zen-dark-rgb), 0.12);
   border-radius: 8px;
   background: transparent;
   cursor: pointer;
@@ -843,4 +879,90 @@ button svg {
 
 .color-picker:hover {
   border-color: var(--accent-color);
+}
+
+/* Theme color grid — dual dark/light swatch pickers */
+.theme-color-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.theme-color-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.theme-color-swatch {
+  width: 100%;
+  height: 60px;
+  border-radius: 10px;
+  border: 1px solid rgba(var(--zen-dark-rgb), 0.15);
+  position: relative;
+  cursor: pointer;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease;
+  overflow: hidden;
+}
+
+.theme-color-swatch:hover {
+  border-color: var(--accent-color);
+  box-shadow: 0 0 0 2px rgba(247, 111, 83, 0.15);
+}
+
+.theme-color-swatch input[type="color"] {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  cursor: pointer;
+  border: none;
+  padding: 0;
+}
+
+.theme-color-label {
+  font-size: 0.78rem;
+  color: rgba(var(--zen-dark-rgb), 0.5);
+  font-family: "Vollkorn", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto;
+  letter-spacing: 0.05em;
+  text-transform: lowercase;
+}
+
+/* Theme selector */
+.theme-selector {
+  display: flex;
+  gap: 0.25rem;
+  background: rgba(var(--zen-dark-rgb), 0.05);
+  padding: 0.25rem;
+  border-radius: 10px;
+  border: 1px solid rgba(var(--zen-dark-rgb), 0.12);
+}
+
+.theme-option {
+  flex: 1;
+  padding: 0.65rem 1rem;
+  background: transparent;
+  border: none;
+  border-radius: 8px;
+  color: rgba(var(--zen-dark-rgb), 0.6);
+  font-family: "Vollkorn", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  font-weight: 400;
+}
+
+.theme-option:hover {
+  color: var(--zen-dark);
+  background: rgba(var(--zen-dark-rgb), 0.05);
+}
+
+.theme-option.active {
+  background: var(--zen-paper);
+  color: var(--zen-dark);
+  border: 1px solid rgba(var(--zen-dark-rgb), 0.15);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }

--- a/home/styles.css
+++ b/home/styles.css
@@ -1,5 +1,9 @@
 /* Style of the Zen Home Page */
 
+:root {
+  --accent-color: rgb(247, 111, 83);
+}
+
 /* Dark theme — default */
 :root,
 html[data-theme="dark"] {
@@ -8,7 +12,6 @@ html[data-theme="dark"] {
   --zen-dark-rgb: 209, 207, 192;
   --zen-muted: rgba(255, 255, 255, 0.05);
   --zen-subtle: rgba(255, 255, 255, 0.1);
-  --accent-color: rgb(247, 111, 83);
 }
 
 /* Light theme */
@@ -18,7 +21,6 @@ html[data-theme="light"] {
   --zen-dark-rgb: 42, 40, 38;
   --zen-muted: rgba(0, 0, 0, 0.04);
   --zen-subtle: rgba(0, 0, 0, 0.08);
-  --accent-color: rgb(247, 111, 83);
 }
 
 /* System theme — delegates to OS preference */
@@ -29,7 +31,6 @@ html[data-theme="light"] {
     --zen-dark-rgb: 42, 40, 38;
     --zen-muted: rgba(0, 0, 0, 0.04);
     --zen-subtle: rgba(0, 0, 0, 0.08);
-    --accent-color: rgb(247, 111, 83);
   }
 }
 
@@ -40,7 +41,6 @@ html[data-theme="light"] {
     --zen-dark-rgb: 209, 207, 192;
     --zen-muted: rgba(255, 255, 255, 0.05);
     --zen-subtle: rgba(255, 255, 255, 0.1);
-    --accent-color: rgb(247, 111, 83);
   }
 }
 

--- a/home/styles.css
+++ b/home/styles.css
@@ -945,7 +945,7 @@ button svg {
   flex: 1;
   padding: 0.65rem 1rem;
   background: transparent;
-  border: none;
+  border: 1px solid transparent;
   border-radius: 8px;
   color: rgba(var(--zen-dark-rgb), 0.6);
   font-family: "Vollkorn", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto;
@@ -963,6 +963,6 @@ button svg {
 .theme-option.active {
   background: var(--zen-paper);
   color: var(--zen-dark);
-  border: 1px solid rgba(var(--zen-dark-rgb), 0.15);
+  border-color: rgba(var(--zen-dark-rgb), 0.15);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }


### PR DESCRIPTION


https://github.com/user-attachments/assets/ecea2d23-549f-4eb9-864b-b9f0f03e506b



## Summary

  Adds a full theme switching system to the new tab page, replacing the previously hardcoded dark-only appearance.

  ### Theme toggle
  - New Appearance section in Settings with Dark / Light / System segmented control
  - Theme preference persisted in `browser.storage.local` (survives history clearing)
  - `localStorage` used as a synchronous cache for FOUT prevention — an inline script in `<head>` applies the correct theme and background color before first paint, eliminating any
  flash of unstyled content
  - System option respects `prefers-color-scheme` both at paint time and on theme switch

  ### Per-theme background colors
  - Each theme (dark/light) independently stores its own background color
  - Color tab redesigned with side-by-side Dark/Light swatches — both apply in a single click
  - Custom color is applied via `--zen-paper` CSS variable override, keeping all dependent styles in sync without additional JS
  - "Clear Background" scoped correctly to wallpaper only — color preferences are preserved
  - "Reset All" remains the only action that wipes both wallpaper and color settings

  ### CSS architecture
  - All colour values migrated to CSS custom properties (`--zen-dark`, `--zen-dark-rgb`, `--zen-muted`, `--zen-subtle`) per theme block
  - Replaced all hardcoded `rgba(209, 207, 192, ...)` values with `rgba(var(--zen-dark-rgb), ...)` throughout, including inline styles
  - Settings icon SVG inlined to allow `fill: currentColor` theming in light mode

  ### Bug fixes
  - Race condition on theme switch: `applyTheme` now synchronously applies the cached color from `localStorage` before the async `browser.storage.local` read completes, preventing a
  brief flash of the previous theme's custom color
  - `loadThemeBgColor` no longer writes an empty string to the localStorage cache when no color is stored — absent keys are now explicitly removed
  - Removed duplicate `<link rel="preconnect">` tags for Google Fonts
  - Live preview panel moved inside the Image tab — no longer visible when the Color tab is active

  ## Test plan
  - [ ] Fresh install (no prior localStorage): verify page loads with correct OS-matching theme, no dark flash on light-mode systems
  - [ ] Switch between Dark / Light / System in Settings — page background, text, and icon colours update immediately
  - [ ] Set a custom dark color, switch to Light, switch back to Dark — custom color is restored without flicker
  - [ ] Upload a wallpaper, click Clear Background — wallpaper removed, custom color preference preserved
  - [ ] Click Reset All — both wallpaper and color preferences cleared, defaults restored
  - [ ] Open Settings → Background → Color tab: no preview panel visible. Switch to Image tab: preview appears at top
  - [ ] Verify Effects label and Reset All button background render correctly in both Light and Dark themes